### PR TITLE
Grain replication

### DIFF
--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,9 +48,10 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(1901)
+      .setUDPPort(1900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,9 +48,10 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(19010)
+      .setUDPPort(1900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)
@@ -74,7 +75,6 @@ object Main {
     master.start()
     slave.start()
     slave2.start()
-//    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -74,7 +74,7 @@ object Main {
     master.start()
     slave.start()
     slave2.start()
-    slave3.start()
+//    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -50,8 +50,8 @@ object Main {
       .registerGrain[TwitterAccount]
       .registerGrain[GreeterGrain]
       .setHost("localhost")
-      .setTCPPort(1800)
-      .setUDPPort(1900)
+      .setTCPPort(2800)
+      .setUDPPort(2900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -34,6 +34,7 @@ object Main {
     val slave = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1600)
       .setUDPPort(1700)
@@ -49,7 +50,7 @@ object Main {
       .registerGrain[TwitterAccount]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(19010)
+      .setUDPPort(1901)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)
@@ -74,6 +75,9 @@ object Main {
     slave.start()
     slave2.start()
     slave3.start()
+
+    Thread.sleep(1000 * 20)
+
     //master.stop()
     //slave.stop()
   }

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,10 +48,9 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
-      .registerGrain[GreeterGrain]
       .setHost("localhost")
-      .setTCPPort(2800)
-      .setUDPPort(2900)
+      .setTCPPort(1800)
+      .setUDPPort(19010)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Master.scala
+++ b/src/main/scala/org/orleans/silo/Master.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.orleans.silo.Services.Grain.Grain
 import org.orleans.silo.communication.ConnectionProtocol.{Packet, PacketType, SlaveInfo}
 import org.orleans.silo.communication.{PacketListener, PacketManager, ConnectionProtocol => protocol}
-import org.orleans.silo.control.MasterGrain
+import org.orleans.silo.control.{GrainType, MasterGrain}
 import org.orleans.silo.dispatcher.Dispatcher
 import org.orleans.silo.metrics.LoadMonitor
 import org.orleans.silo.utils.GrainState.GrainState
@@ -111,8 +111,8 @@ class Master(
   val grainMap: ConcurrentHashMap[String, List[GrainInfo]] =
     new ConcurrentHashMap[String, List[GrainInfo]]()
 
-  val grainClassMap: ConcurrentHashMap[String, (ClassTag[_ <: Grain], TypeTag[_ <: Grain])] =
-    new ConcurrentHashMap[String, (ClassTag[_ <: Grain], TypeTag[_ <: Grain])]()
+  val grainClassMap: ConcurrentHashMap[String, GrainType[_ <: Grain]] =
+    new ConcurrentHashMap[String, GrainType[_ <: Grain]]()
 
   // Metadata for the master.
   val uuid: String = UUID.randomUUID().toString
@@ -364,9 +364,8 @@ class Master(
     * @param port   The port receiving from.
     */
   def processLoadData(packet: Packet, host: String, port: Int): Unit = {
-    logger.warn(s"Processing load data: ${packet.data} from slave ${packet.uuid}")
-    grainMap.forEach((k, v) => logger.warn(k + ":" + v))
-    grainClassMap.forEach((k, v) => logger.warn(k + ":" + v))
+    logger.debug(s"Processing load data: ${packet.data} from slave ${packet.uuid}")
+    grainMap.forEach((k, v) => logger.debug(k + ":" + v))
     packet.data.foreach { d =>
       d.split(":") match {
         case Array(id, load) => {
@@ -405,7 +404,7 @@ class Master(
           .foldLeft(0)((acc, b) => acc + b.load)
       })
       v.totalLoad = totalLoad
-      logger.warn("Slave load " + k + ":" + v.totalLoad)
+      logger.debug("Slave load " + k + ":" + v.totalLoad)
     }
   }
 

--- a/src/main/scala/org/orleans/silo/Master.scala
+++ b/src/main/scala/org/orleans/silo/Master.scala
@@ -285,7 +285,7 @@ class Master(
     *
     * @param packet The handshake packet.
     * @param host   The host receiving from.
-    * @param port   The port receiving from.
+    * @param udpPort   The port receiving from.
     */
   def processHandshake(packet: Packet, host: String, udpPort: Int): Unit = {
     // If slave is already in the cluster, we will not send another welcome packet. Its probably already received.

--- a/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
+++ b/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
@@ -22,5 +22,8 @@ class GreeterGrain(_id: String) extends Grain(_id) with LazyLogging {
       // Answer to the sender of the message
       // Asynchronous response
       sender ! "Hello World!"
+    case (msg: String, _) =>
+      Thread.sleep(25)
+      logger.info(s"Received message $msg")
   }
 }

--- a/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
+++ b/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
@@ -16,13 +16,16 @@ class GreeterGrain(_id: String) extends Grain(_id) with LazyLogging {
     */
   def receive = {
     case ("hi", _) =>
+      Thread.sleep(5000)
       logger.info("Hello back to you")
     case ("hello", sender: Sender) =>
+      Thread.sleep(5000)
       logger.info("Replying to the sender!")
       // Answer to the sender of the message
       // Asynchronous response
       sender ! "Hello World!"
     case (msg: String, _) =>
+      Thread.sleep(5000)
       Thread.sleep(25)
       logger.info(s"Received message $msg")
   }

--- a/src/main/scala/org/orleans/silo/Test/TestLoadBalancing.scala
+++ b/src/main/scala/org/orleans/silo/Test/TestLoadBalancing.scala
@@ -1,0 +1,129 @@
+package org.orleans.silo.Test
+
+import org.orleans.silo.Services.Grain.GrainRef
+import org.orleans.silo.control.{ActiveGrainRequest, ActiveGrainResponse, CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+import scala.reflect.runtime.universe._
+import scala.reflect._
+
+object TestLoadBalancing {
+  // Testing load balancing.
+  // NOTE: To observe the effect add a Thread.sleep() to GreeterGrain receive() method.
+  def main(args: Array[String]): Unit = {
+    println("Trying to get the socket")
+
+    var id: String = ""
+
+    val classtag = classTag[GreeterGrain]
+    val typetag = typeTag[GreeterGrain]
+
+    // The master grain in the master has ID "master" so it's easy to find!
+    val g = GrainRef("master", "localhost", 1400)
+
+    // Try to create a grain
+    println("Creating the grain!")
+    val result = g ? CreateGrainRequest(classtag, typetag)
+    val mappedResult = result.map {
+      case value: CreateGrainResponse =>
+        println("Received CreateGrainResponse!")
+        println(value)
+        id = value.id
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResult, 5 seconds)
+
+    println(s"ID of the grain is $id")
+
+    // Search for the grain.
+    // Only 1 activation exists by now.
+    println("Searching for the grain")
+    var port : Int = 0
+    // Search for a grain
+    g ? SearchGrainRequest(id, classtag, typetag) onComplete {
+      case Success(value: SearchGrainResponse) =>
+        println(value)
+        port = value.port
+      case Failure(exception) => exception.printStackTrace()
+    }
+    Thread.sleep(1000)
+
+    // Turn on logging in Master's processLoadData() method and
+    // see how the queue piles up.
+    println("Sending hello to the greeter grain")
+    val g1 : GrainRef = GrainRef(id, "localhost", port)
+    for (i ← (1 to 15)) {
+      Thread.sleep(250)
+      g1 ! s"hello from $i"
+    }
+
+    Thread.sleep(3000)
+    // Create another activation of the same grain.
+    // Also see if the activation will be created on different slave (It should).
+    println("Try to activate other grain")
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(2000)
+
+    // Create another grain.
+    // Also see if the grain will be created on different slave (It should).
+//    var id1 = ""
+//    println("Creating the other grain!")
+//    val result1 = g ? CreateGrainRequest(classtag, typetag)
+//    val mappedResult1 = result1.map {
+//      case value: CreateGrainResponse =>
+//        println("Received CreateGrainResponse!")
+//        println(value)
+//        id1 = value.id
+//      case other => println(s"Something went wrong: $other")
+//    }
+//    Await.result(mappedResult1, 5 seconds)
+//
+//    println(s"ID of the grain is $id1")
+
+    // Search for the grain.
+    // 2 activations exists. Searching should return slave with lower total load.
+    // (See the logs in Master's processLoadData() method to verify)
+    var port2 = 0
+    println("Searching for the grain")
+    g ? SearchGrainRequest(id, classtag, typetag) onComplete {
+      case Success(value: SearchGrainResponse) =>
+        println(value)
+        port2 = value.port
+      case Failure(exception) => exception.printStackTrace()
+    }
+    Thread.sleep(1000)
+
+    println("Sending hello to the greeter grain")
+    val g2 : GrainRef = GrainRef(id, "localhost", port2)
+    for (i ← (1 to 15)) {
+      Thread.sleep(250)
+      g2 ! s"hello from $i"
+    }
+
+    Thread.sleep(500000)
+
+    // Delete that grain
+    println("Trying to delete grain")
+    // Try to delete the grain
+    g ! DeleteGrainRequest(id)
+  }
+
+  def time[R](block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block // call-by-name
+    val t1 = System.nanoTime()
+    println("Elapsed time: " + (t1 - t0) / 1e6 + "ms")
+    result
+  }
+}

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -1,7 +1,7 @@
 package org.orleans.silo.Test
 
 import org.orleans.silo.Services.Grain.GrainRef
-import org.orleans.silo.control.{CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
+import org.orleans.silo.control.{ActiveGrainRequest, ActiveGrainResponse, CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -27,19 +27,19 @@ object Testing {
 //    val g = GrainRef("1234", "localhost", 1400)
 
     // Try to search for a grain that is deactivated
-    g ? SearchGrainRequest("29d95c86-b744-43cc-9de3-23a0e40c21c3", classtag, typetag) onComplete {
-      case Success(value: SearchGrainResponse) =>
-        println("Succesfully activate persistant grain by search!")
-        println(value)
-      case Success(value) =>
-        println(s"Unknown return value received: $value!")
-      case Failure(exception) => exception.printStackTrace()
-    }
-    Thread.sleep(1000)
+//    g ? SearchGrainRequest("962d24a3-5b31-41ba-aaeb-60ca4bd69b4d", classtag, typetag) onComplete {
+//      case Success(value: SearchGrainResponse) =>
+//        println("Succesfully activate persistant grain by search!")
+//        println(value)
+//      case Success(value) =>
+//        println(s"Unknown return value received: $value!")
+//      case Failure(exception) => exception.printStackTrace()
+//    }
+//    Thread.sleep(100000)
 
 
 
-    // Try to create a grain
+//     Try to create a grain
     println("Creating the grain!")
     val result = g ? CreateGrainRequest(classtag, typetag)
     val mappedResult = result.map {
@@ -52,7 +52,32 @@ object Testing {
     Await.result(mappedResult, 5 seconds)
 
     println(s"ID of the grain is $id")
+
+    Thread.sleep(3000)
+    println("Try to activate other grain")
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(5000)
     println("Searching for the grain")
+
+    println("Try to activate other grain")
+    val resultActivate1 = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate1 = resultActivate1.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate1, 5 seconds)
+
+    Thread.sleep(5000)
 
     var port : Int = 0
 
@@ -63,7 +88,7 @@ object Testing {
         port = value.port
       case Failure(exception) => exception.printStackTrace()
     }
-    Thread.sleep(1000)
+    Thread.sleep(5000)
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
@@ -72,8 +97,8 @@ object Testing {
       case _ => "Not working"
     }
 
-    Thread.sleep(5000)
-
+    Thread.sleep(15000)
+//
     // Delete that grain
     println("Trying to delete grain")
     // Try to delete the grain

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -56,16 +56,16 @@ object Testing {
     Thread.sleep(3000)
 //    Create another activation to test replication on the same slave (to test, you need to start only 1 slave)
 //    println("Try to activate other grain")
-//    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
-//    val mappedResultActivate = resultActivate.map {
-//      case value: ActiveGrainResponse =>
-//        println("Received ActiveGrainResponse!")
-//        println(value)
-//      case other => println(s"Something went wrong: $other")
-//    }
-//    Await.result(mappedResultActivate, 5 seconds)
-//
-//    Thread.sleep(5000)
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(5000)
     println("Searching for the grain")
     var port : Int = 0
 
@@ -80,17 +80,20 @@ object Testing {
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
-    g2 ? "hello" onComplete{
-      case Success(value) => println(value)
-      case _ => "Not working"
+    for (i ← (1 to 1000)) {
+      g2 ! s"hello from $i"
     }
+//    g2 ? "hello" onComplete{
+//      case Success(value) => println(value)
+//      case _ => "Not working"
+//    }
 
     Thread.sleep(5000)
 //
     // Delete that grain
-    println("Trying to delete grain")
-    // Try to delete the grain
-    g ! DeleteGrainRequest(id)
+//    println("Trying to delete grain")
+//    // Try to delete the grain
+//    g ! DeleteGrainRequest(id)
 
   }
 

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -54,31 +54,19 @@ object Testing {
     println(s"ID of the grain is $id")
 
     Thread.sleep(3000)
-    println("Try to activate other grain")
-    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
-    val mappedResultActivate = resultActivate.map {
-      case value: ActiveGrainResponse =>
-        println("Received ActiveGrainResponse!")
-        println(value)
-      case other => println(s"Something went wrong: $other")
-    }
-    Await.result(mappedResultActivate, 5 seconds)
-
-    Thread.sleep(5000)
+//    Create another activation to test replication on the same slave (to test, you need to start only 1 slave)
+//    println("Try to activate other grain")
+//    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+//    val mappedResultActivate = resultActivate.map {
+//      case value: ActiveGrainResponse =>
+//        println("Received ActiveGrainResponse!")
+//        println(value)
+//      case other => println(s"Something went wrong: $other")
+//    }
+//    Await.result(mappedResultActivate, 5 seconds)
+//
+//    Thread.sleep(5000)
     println("Searching for the grain")
-
-    println("Try to activate other grain")
-    val resultActivate1 = g ? ActiveGrainRequest(id, classtag, typetag)
-    val mappedResultActivate1 = resultActivate1.map {
-      case value: ActiveGrainResponse =>
-        println("Received ActiveGrainResponse!")
-        println(value)
-      case other => println(s"Something went wrong: $other")
-    }
-    Await.result(mappedResultActivate1, 5 seconds)
-
-    Thread.sleep(5000)
-
     var port : Int = 0
 
     // Search for a grain
@@ -88,7 +76,7 @@ object Testing {
         port = value.port
       case Failure(exception) => exception.printStackTrace()
     }
-    Thread.sleep(5000)
+    Thread.sleep(1000)
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
@@ -97,7 +85,7 @@ object Testing {
       case _ => "Not working"
     }
 
-    Thread.sleep(15000)
+    Thread.sleep(5000)
 //
     // Delete that grain
     println("Trying to delete grain")

--- a/src/main/scala/org/orleans/silo/control/GrainType.scala
+++ b/src/main/scala/org/orleans/silo/control/GrainType.scala
@@ -1,0 +1,8 @@
+package org.orleans.silo.control
+
+import org.orleans.silo.Services.Grain.Grain
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+case class GrainType[T <: Grain](classTag: ClassTag[T], typeTag: TypeTag[T])

--- a/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
@@ -35,7 +35,7 @@ class SlaveGrain(_id: String, slave: Slave)
   private def getOrCreateDispatcher[T <: Grain: ClassTag: TypeTag]()
     : Dispatcher[T] = {
     if (!slave.registeredGrains.exists(tuple => tuple._1 == classTag[T])) {
-      logger.info(s"Creating new dispatcher for class: ${typeTag}")
+      logger.warn(s"Creating new dispatcher for class: ${typeTag}")
       val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
@@ -55,7 +55,7 @@ class SlaveGrain(_id: String, slave: Slave)
         .head
         .asInstanceOf[Dispatcher[T]]
 
-      logger.info(s"Found dispatcher for class: ${typeTag}")
+      logger.warn(s"Found dispatcher for class: ${typeTag}")
 
       dispatcher
     }
@@ -204,7 +204,9 @@ class SlaveGrain(_id: String, slave: Slave)
     dispatcher.addActivation(request.id, request.grainType)
 
     // Add it to the grainMap
-    logger.info(s"Adding to the slave grainmap id ${request.id}")
+    logger.info(s"Adding activation to the slave grainmap id ${request.id}")
+
+    //TODO GrainMap has to differentiate grains by port also
     slave.grainMap.put(request.id, classTag[T])
 
     sender ! ActiveGrainResponse(slave.slaveConfig.host, dispatcher.port)

--- a/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
@@ -36,7 +36,7 @@ class SlaveGrain(_id: String, slave: Slave)
     : Dispatcher[T] = {
     if (!slave.registeredGrains.exists(tuple => tuple._1 == classTag[T])) {
       logger.warn(s"Creating new dispatcher for class: ${typeTag}")
-      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
+      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort, Option(null))
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
 
@@ -55,7 +55,7 @@ class SlaveGrain(_id: String, slave: Slave)
         .head
         .asInstanceOf[Dispatcher[T]]
 
-      logger.warn(s"Found dispatcher for class: ${typeTag}")
+      logger.debug(s"Found dispatcher for class: ${typeTag}")
 
       dispatcher
     }
@@ -135,7 +135,7 @@ class SlaveGrain(_id: String, slave: Slave)
       logger.debug(
         s"Creating new dispatcher for class ${request.grainClass.runtimeClass}")
       // Create a new dispatcher for that and return its properties
-      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
+      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort, Option(null))
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
       val id: String = dispatcher.addGrain(typeTag)
@@ -206,7 +206,6 @@ class SlaveGrain(_id: String, slave: Slave)
     // Add it to the grainMap
     logger.info(s"Adding activation to the slave grainmap id ${request.id}")
 
-    //TODO GrainMap has to differentiate grains by port also
     slave.grainMap.put(request.id, classTag[T])
 
     sender ! ActiveGrainResponse(slave.slaveConfig.host, dispatcher.port)

--- a/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
@@ -17,7 +17,7 @@ import collection.JavaConverters._
 class ClientCleanup(clientSockets: util.List[MessageReceiver])
     extends TimerTask
     with LazyLogging {
-  val CLIENT_REMOVE_TIME_SEC: Int = 10
+  val CLIENT_REMOVE_TIME_SEC: Int = 100000
   override def run(): Unit = {
     val toRemove: util.List[MessageReceiver] =
       new util.ArrayList[MessageReceiver]()
@@ -46,7 +46,7 @@ class ClientCleanup(clientSockets: util.List[MessageReceiver])
   }
 }
 class ClientReceiver[T <: Grain: ClassTag](
-    val mailboxIndex: ConcurrentHashMap[String, Mailbox],
+    val mailboxIndex: ConcurrentHashMap[String, List[Mailbox]],
     port: Int)
     extends Runnable
     with LazyLogging {

--- a/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
@@ -17,7 +17,7 @@ import collection.JavaConverters._
 class ClientCleanup(clientSockets: util.List[MessageReceiver])
     extends TimerTask
     with LazyLogging {
-  val CLIENT_REMOVE_TIME_SEC: Int = 100000
+  val CLIENT_REMOVE_TIME_SEC: Int = 10
   override def run(): Unit = {
     val toRemove: util.List[MessageReceiver] =
       new util.ArrayList[MessageReceiver]()
@@ -47,7 +47,7 @@ class ClientCleanup(clientSockets: util.List[MessageReceiver])
 }
 class ClientReceiver[T <: Grain: ClassTag](
     val mailboxIndex: ConcurrentHashMap[String, List[Mailbox]],
-    port: Int)
+    port: Int, val registryFactory: Option[RegistryFactory])
     extends Runnable
     with LazyLogging {
 
@@ -86,7 +86,7 @@ class ClientReceiver[T <: Grain: ClassTag](
       }
 
       // Create new client when
-      val messageReceiver = new MessageReceiver(mailboxIndex, clientSocket)
+      val messageReceiver = new MessageReceiver(mailboxIndex, registryFactory, clientSocket)
       val mRecvThread: Thread = new Thread(messageReceiver)
       logger.info(s"Message-Receiver started on ${clientSocket.getPort}.")
       mRecvThread.setName(

--- a/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
@@ -106,6 +106,7 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
     val mailbox = new Mailbox(grain, registryFactory)
 
     this.grainMap.put(mailbox, grain)
+    this.grainMap.forEach((mbox, grain) => logger.info(s"Mailbox ${mbox.id} --> $grain"))
     val currentMailboxes: List[Mailbox] = this.clientReceiver.mailboxIndex.getOrDefault(grain._id, List())
     this.clientReceiver.mailboxIndex.put(grain._id, mailbox :: currentMailboxes)
   }
@@ -188,6 +189,7 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
           pool.execute(mbox)
         }
       })
+      Thread.sleep(SLEEP_TIME)
     }
   }
 

--- a/src/main/scala/org/orleans/silo/dispatcher/Mailbox.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/Mailbox.scala
@@ -2,6 +2,7 @@ package org.orleans.silo.dispatcher
 
 import java.io.ObjectOutputStream
 import java.net.Socket
+import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -48,7 +49,7 @@ private[dispatcher] class Mailbox(val grain: Grain, val registryFactory: Option[
     with LazyLogging {
   private[dispatcher] val inbox = new LinkedBlockingQueue[Message]
   // id of the mailbox
-  val id: String = grain._id
+  val id: String = UUID.randomUUID().toString
 
   // length of the message queue for that actor
   def length: Int = inbox.size()
@@ -87,7 +88,7 @@ private[dispatcher] class Mailbox(val grain: Grain, val registryFactory: Option[
       grain.receive((msg.msg, msg.sender))
       if (registryFactory.isDefined) {
         val registry: Registry =
-          registryFactory.get.getOrCreateRegistry(id)
+          registryFactory.get.getOrCreateRegistry(grain._id)
         registry.addRequestHandled()
       }
     }

--- a/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
@@ -1,0 +1,39 @@
+package org.orleans.silo.metrics
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.typesafe.scalalogging.LazyLogging
+import org.orleans.silo.GrainInfo
+import org.orleans.silo.control.MasterGrain
+
+class LoadMonitor(val grainMap: ConcurrentHashMap[String, List[GrainInfo]], val masterGrain: MasterGrain)
+  extends Runnable with LazyLogging{
+
+  var running: Boolean = true
+  val FREQUENCY: Int = 1000
+  // Final value to figure out
+  val REPLICATION_TRESHOLD = 10
+
+  override def run(): Unit = {
+    logger.warn("Started load monitor on master.")
+    var oldTime: Long = System.currentTimeMillis()
+
+    while (running) {
+      val newTime: Long = System.currentTimeMillis()
+      val timeDiff = newTime - oldTime
+
+      // Check if it is time to send heartbeats again.
+      if (timeDiff >= FREQUENCY) {
+        oldTime = newTime
+        grainMap.forEach((id, grainList) => {
+          val avgLoad: Double = grainList.foldLeft(0.0)((acc, b) => acc + b.load) / grainList.length
+          if (avgLoad > REPLICATION_TRESHOLD) {
+            masterGrain.triggerGrainReplication(id)
+          }
+        }
+        )
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
@@ -12,7 +12,7 @@ class LoadMonitor(val grainMap: ConcurrentHashMap[String, List[GrainInfo]], val 
   var running: Boolean = true
   val FREQUENCY: Int = 1000
   // Final value to figure out
-  val REPLICATION_TRESHOLD = 10
+  val REPLICATION_TRESHOLD = 100
 
   override def run(): Unit = {
     logger.warn("Started load monitor on master.")

--- a/src/main/scala/org/orleans/silo/metrics/MetricsExtractor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/MetricsExtractor.scala
@@ -8,8 +8,8 @@ object MetricsExtractor {
    * @return Number of pending requests.
    */
   def getPendingRequests(registry: Registry): Int = {
-    val started = registry.requestsReceived
-    val handled = registry.requestsHandled
+    val started = registry.requestsReceived.get()
+    val handled = registry.requestsHandled.get()
     started - handled
   }
 

--- a/src/main/scala/org/orleans/silo/metrics/Registry.scala
+++ b/src/main/scala/org/orleans/silo/metrics/Registry.scala
@@ -1,25 +1,25 @@
 package org.orleans.silo.metrics
 
+import java.util.concurrent.atomic.AtomicInteger
+
 /**
  * Registry for collecting information about requests toi grain.
  */
 class Registry() {
-  @volatile
-  var requestsReceived: Int = 0
-  @volatile
-  var requestsHandled: Int = 0
+  var requestsReceived: AtomicInteger = new AtomicInteger(0)
+  var requestsHandled: AtomicInteger = new AtomicInteger(0)
 
   /**
    * Increase the counter of requests received.
    */
   def addRequestReceived(): Unit = {
-    requestsReceived += 1
+    requestsReceived.addAndGet(1)
   }
 
   /**
    * Increase the counter of requests processed.
    */
   def addRequestHandled(): Unit = {
-    requestsHandled += 1
+    requestsHandled.addAndGet(1)
   }
 }

--- a/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
+++ b/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import com.typesafe.scalalogging.LazyLogging
 import org.orleans.silo.GrainInfo
 
-object RegistryFactory extends LazyLogging{
+class RegistryFactory extends LazyLogging{
 
   // Active registries collecting metrics on different services.
   private val registries: ConcurrentHashMap[String, Registry] = new ConcurrentHashMap[String, Registry]()


### PR DESCRIPTION
Changes:

- Multiple activations of the same grain are now possible on the same slave. MailboxIndex now store List of Mailboxes and MessageReceiver chooses a mailbox to put a message to by the current size of the mailbox.

- RegistryFactory for grains is now instantiated for each slave (not global anymore) so we don't have this spam of logs when we test locally. Note that metrics will be collected only for grain types that you register when starting the slaves.

- Minor changes in storing the grainMap in Master i.e: avoid duplication of entries form the replicas of the same grain on the same slave (master sees such activations as one).