### PR TITLE
Grain replication

### DIFF
--- a/deployment/kubernetes/02-master-deployment.yml
+++ b/deployment/kubernetes/02-master-deployment.yml
@@ -16,30 +16,30 @@ spec:
         component: master
     spec:
       containers:
-      - name: master
-        image: wzorgdrager/orleans:1.7
-        args:
-        - "0"
-        - "master"
-        - "1400"
-        - "1500"
-        - "1501"
-        - "1510"
-        ports:
-        - containerPort: 1400
-        - containerPort: 1500
-        - containerPort: 1501
-        - containerPort: 1502
-        - containerPort: 1503
-        - containerPort: 1504
-        - containerPort: 1505
-        - containerPort: 1506
-        - containerPort: 1507
-        - containerPort: 1508
-        - containerPort: 1509
-        - containerPort: 1510
+        - name: master
+          image: wzorgdrager/orleans:5.1
+          args:
+            - "0"
+            - "master"
+            - "1400"
+            - "1500"
+            - "1501"
+            - "1510"
+          ports:
+            - containerPort: 1400
+            - containerPort: 1500
+            - containerPort: 1501
+            - containerPort: 1502
+            - containerPort: 1503
+            - containerPort: 1504
+            - containerPort: 1505
+            - containerPort: 1506
+            - containerPort: 1507
+            - containerPort: 1508
+            - containerPort: 1509
+            - containerPort: 1510
     env:
-    - name: HOSTNAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+      - name: HOSTNAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name

--- a/deployment/kubernetes/03-slaves-deployment.yml
+++ b/deployment/kubernetes/03-slaves-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: slave
   namespace: orleans
 spec:
-  replicas: 5
+  replicas: 1
   serviceName: slave-headless
   selector:
     matchLabels:
@@ -17,34 +17,34 @@ spec:
         component: slave
     spec:
       containers:
-      - name: slave
-        image: wzorgdrager/orleans:1.7
-        args:
-        - "0"
-        - "slave"
-        - "1400"
-        - "1500"
-        - "1501"
-        - "1510"
-        - "master.orleans"
-        - "1400"
-        - "1500"
-        ports:
-        - containerPort: 1400
-        - containerPort: 1500
-        - containerPort: 1501
-        - containerPort: 1502
-        - containerPort: 1503
-        - containerPort: 1504
-        - containerPort: 1505
-        - containerPort: 1506
-        - containerPort: 1507
-        - containerPort: 1508
-        - containerPort: 1509
-        - containerPort: 1510
+        - name: slave
+          image: wzorgdrager/orleans:5.1
+          args:
+            - "0"
+            - "slave"
+            - "1400"
+            - "1500"
+            - "1501"
+            - "1510"
+            - "master.orleans"
+            - "1400"
+            - "1500"
+          ports:
+            - containerPort: 1400
+            - containerPort: 1500
+            - containerPort: 1501
+            - containerPort: 1502
+            - containerPort: 1503
+            - containerPort: 1504
+            - containerPort: 1505
+            - containerPort: 1506
+            - containerPort: 1507
+            - containerPort: 1508
+            - containerPort: 1509
+            - containerPort: 1510
     env:
-    - name: HOSTNAME
-      valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
+      - name: HOSTNAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: status.podIP

--- a/deployment/kubernetes/04-client.yml
+++ b/deployment/kubernetes/04-client.yml
@@ -1,24 +1,24 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: orleans-client-scenario-3-5-slaves
+  name: orleans-client-scenario-8-15-slaves
   namespace: orleans
 spec:
-  completions: 1
+  completions: 5
   template:
     spec:
       containers:
-      - name: client
-        image: wzorgdrager/orleans:1.8
-        args:
-        - "1"
-        - "client"
-        - "3"
-        - "master.orleans"
-        - "1400"
+        - name: client
+          image: wzorgdrager/orleans:5.4
+          args:
+            - "1"
+            - "client"
+            - "8"
+            - "master.orleans"
+            - "1400"
       restartPolicy: Never
     env:
-    - name: HOSTNAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+      - name: HOSTNAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name

--- a/src/main/scala/org/orleans/Main.scala
+++ b/src/main/scala/org/orleans/Main.scala
@@ -1,25 +1,27 @@
 package org.orleans
+import java.security.MessageDigest
+import java.util
+
 import ch.qos.logback.classic.Level
 import org.orleans.client.OrleansRuntime
-import org.orleans.developer.twitter.{
-  Twitter,
-  TwitterAccount,
-  TwitterAcountRef,
-  TwitterRef
-}
+import org.orleans.developer.crypto.{Hasher, HasherRef}
+import org.orleans.developer.twitter.{Twitter, TwitterAccount, TwitterAcountRef, TwitterRef}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.orleans.silo.Main.setLevel
 import org.orleans.silo.storage.{GrainDatabase, MongoGrainDatabase}
 import org.orleans.silo.{Master, Slave}
 
+import scala.collection.mutable
+import collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Random, Success}
 
 object Main {
 
   def main(args: Array[String]): Unit = {
+    GrainDatabase.disableDatabase = true
     setLevel(Level.INFO) // The debug level might give a little bit too much info.
     args.toList match {
       case level :: "master" :: tail if isInt(level) => {
@@ -107,6 +109,11 @@ object Main {
       case 1 => runClientScenarioOne(masterHost, masterTCP)
       case 2 => runClientScenarioTwo(masterHost, masterTCP)
       case 3 => runClientScenarioThree(masterHost, masterTCP)
+      case 4 => runClientScenarioFour(masterHost, masterTCP)
+      case 5 => runClientScenarioFive(masterHost, masterTCP)
+      case 6 => runClientScenarioSix(masterHost, masterTCP)
+      case 7 => runClientScenarioSeven(masterHost, masterTCP)
+      case 8 => runClientScenarioEight(masterHost, masterTCP)
       case _ => throw new RuntimeException("Can't find client scenario.")
     }
     println(
@@ -121,6 +128,7 @@ object Main {
                 graintPortEnd: Int): Unit = {
     GrainDatabase.disableDatabase = true
     Master()
+      .registerGrain[Hasher]
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
       .setHost(host)
@@ -142,6 +150,7 @@ object Main {
                masterUDP: Int): Unit = {
     GrainDatabase.disableDatabase = true
     Slave()
+      .registerGrain[Hasher]
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
       .setHost(host)
@@ -303,6 +312,270 @@ object Main {
       Thread.sleep(50)
     }
     //Await.result(twitter.createAccount(s"wouter-${i}"), 1 seconds)
+  }
+
+  def runClientScenarioFour(masterHost: String, tcpPort: Int): Unit = {
+    GrainDatabase.disableDatabase = true
+    val runtime = OrleansRuntime()
+      .registerGrain[Twitter]
+      .registerGrain[TwitterAccount]
+      .setHost(masterHost)
+      .setPort(tcpPort)
+      .build()
+
+    var time = System.currentTimeMillis()
+
+    val users = 1000
+    println(s"Now creating $users users.")
+    Await.result(Future.sequence((1 to users).toList.map(_ => runtime.createGrain[TwitterAccount, TwitterAcountRef])), 100 seconds)
+    println(s"That took ${System.currentTimeMillis() - time}ms")
+    System.exit(0)
+
+  }
+
+  def runClientScenarioFive(masterHost: String, tcpPort: Int): Unit = {
+    GrainDatabase.disableDatabase = true
+    val runtime = OrleansRuntime()
+      .registerGrain[Twitter]
+      .registerGrain[TwitterAccount]
+      .setHost(masterHost)
+      .setPort(tcpPort)
+      .build()
+
+    var time = System.currentTimeMillis()
+    val twitterFuture: Future[TwitterRef] =
+      runtime.createGrain[Twitter, TwitterRef]()
+    val twitter = Await.result(twitterFuture, 5 seconds)
+    println(
+      s"Creating a Twitter grain took ${System.currentTimeMillis() - time}ms")
+
+    val userList: util.ArrayList[TwitterAcountRef] = new util.ArrayList[TwitterAcountRef]()
+    val users = 100
+    time = System.currentTimeMillis()
+    for (i <- (1 to users)) {
+      val user: TwitterAcountRef =
+        Await.result(twitter.createAccount(s"wouter-${i}"), 5 seconds)
+      userList.add(user)
+      for (i <- (1 to 10000)) {
+        user.tweet("a tweet!")
+      }
+    }
+
+    println(s"Created users and tweeted: it took ${System.currentTimeMillis() - time}ms")
+
+
+    val hash : mutable.HashMap[String, Int] = new mutable.HashMap[String, Int]()
+        for (user <- userList.asScala.toList) {
+          val tweets = Await.result(user.getTweets(), 5 seconds)
+
+          if (hash.contains(user.grainRef.address)) {
+            hash.put(user.grainRef.address, hash.get(user.grainRef.address).get + 1)
+          } else {
+            hash.put(user.grainRef.address, 1)
+          }
+        }
+    hash.foreach(println(_))
+
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    System.exit(0)
+  }
+
+  def runClientScenarioSix(masterHost: String, tcpPort: Int): Unit = {
+    val runtime = OrleansRuntime()
+      .registerGrain[Hasher]
+      .setHost(masterHost)
+      .setPort(tcpPort)
+      .build()
+
+    val hasherList: util.ArrayList[HasherRef] = new util.ArrayList[HasherRef]()
+    for (i <- 1 to 500) {
+      val hasher = Await.result(runtime.createGrain[Hasher, HasherRef](), 5 seconds)
+      hasherList.add(hasher)
+    }
+
+    println("Created hasherlists.")
+
+
+    var sumTime = 0L
+
+    for (i <- 0 to 100) {
+      val maxInt = 100000
+
+      val message = new Random().nextInt(maxInt)
+
+      val hash = getHash(message)
+
+      //      println(hash)
+
+      var messageFound = false
+      val startTime = System.currentTimeMillis()
+      var futures: List[Future[Option[Int]]] = List()
+
+      for (i <- 0 until hasherList.size()) {
+        val numberOfHashes: Int = maxInt / hasherList.size()
+        val findHashFuture: Future[Option[Int]] = hasherList.get(i).findHash(numberOfHashes * i, numberOfHashes * (i + 1), hash)
+
+        futures = futures :+ findHashFuture
+
+        findHashFuture.onComplete {
+          case Success(Some(value)) =>
+            //            logger.debug(f"Hasher $i has found the original message; $value")
+            messageFound = true
+            println(System.currentTimeMillis() - startTime)
+            sumTime += System.currentTimeMillis() - startTime
+          case _ =>
+        }
+      }
+
+      for (future <- futures) {
+        Await.result(future, 20 seconds)
+      }
+    }
+
+    println(s"avarage: ${sumTime/100}")
+  }
+
+  def runClientScenarioSeven(masterHost: String, tcpPort: Int): Unit = {
+    GrainDatabase.disableDatabase = true
+    val runtime = OrleansRuntime()
+      .registerGrain[Twitter]
+      .registerGrain[TwitterAccount]
+      .setHost(masterHost)
+      .setPort(tcpPort)
+      .build()
+
+
+    val userList: util.ArrayList[TwitterAcountRef] = new util.ArrayList[TwitterAcountRef]()
+    val users = 100
+    var time = System.currentTimeMillis()
+    for (i <- (1 to users)) {
+      println(i)
+      val user: TwitterAcountRef =
+        Await.result(runtime.createGrain[TwitterAccount, TwitterAcountRef], 5 seconds)
+      userList.add(user)
+//      for (i <- (1 to 10000)) {
+//        user.tweet("a tweet!")
+//      }
+    }
+
+    println(s"Created users and tweeted: it took ${System.currentTimeMillis() - time}ms")
+
+
+    val hash : mutable.HashMap[String, Int] = new mutable.HashMap[String, Int]()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 60 seconds)
+    for (user <- userList.asScala.toList) {
+      if (hash.contains(user.grainRef.address)) {
+        hash.put(user.grainRef.address, hash.get(user.grainRef.address).get + 1)
+      } else {
+        hash.put(user.grainRef.address, 1)
+      }
+    }
+    hash.foreach(println(_))
+
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    time = System.currentTimeMillis()
+    Await.result(Future.sequence(userList.asScala.toList.map(_.getTweets())), 30 seconds)
+
+    println(System.currentTimeMillis() - time)
+    System.exit(0)
+  }
+
+  def runClientScenarioEight(masterHost: String, tcpPort: Int) = {
+    GrainDatabase.disableDatabase = true
+    val runtime = OrleansRuntime()
+      .registerGrain[Twitter]
+      .registerGrain[TwitterAccount]
+      .setHost(masterHost)
+      .setPort(tcpPort)
+      .build()
+
+    val userList: util.ArrayList[TwitterAcountRef] = new util.ArrayList[TwitterAcountRef]()
+    val users = 15
+    var time = System.currentTimeMillis()
+    for (i <- 1 to users) {
+      println(i)
+      val user: TwitterAcountRef =
+        Await.result(runtime.createGrain[TwitterAccount, TwitterAcountRef], 5 seconds)
+      userList.add(user)
+    }
+
+    time = System.currentTimeMillis()
+    val tweets = 100000
+    val threadList: util.ArrayList[Thread] = new util.ArrayList[Thread]()
+    for (user <- userList.asScala.toList) {
+      println(user.grainRef.id)
+      val t = new Thread(new Runnable {
+        override def run(): Unit = {
+          (1 to tweets).toList.foreach(x => user.tweet("hi"))
+        }
+      })
+
+        t.start()
+      threadList.add(t)
+
+    }
+    println("send all tweets")
+
+    for (t <- threadList.asScala) {
+      t.join()
+    }
+
+
+//    var notLoaded = true
+//    while(notLoaded) {
+//      val result: List[Int] = Await.result(Future.sequence(userList.asScala.map(_.getAmountOfTweets())), 60 seconds).toList
+//      notLoaded = result.map(_ == tweets).contains(false)
+//
+//      Thread.sleep(10)
+//    }
+
+    val timeDiff = System.currentTimeMillis() - time
+    val throughput = (tweets * users) / timeDiff
+
+    println(throughput)
+    println(s"Send ${tweets*users} tweets in ${timeDiff} ms")
+    val timeSec = timeDiff / 1000
+    println(s"${(tweets * users)/timeSec} messages/second")
+    System.exit(0)
+  }
+
+
+  def getHash(message: Int): String = {
+    MessageDigest.getInstance("SHA-256")
+      .digest(BigInt(message).toByteArray)
+      .map("%02x".format(_)).mkString
   }
 
   /** Very hacky way to set the log level */

--- a/src/main/scala/org/orleans/client/ClientMain.scala
+++ b/src/main/scala/org/orleans/client/ClientMain.scala
@@ -1,14 +1,11 @@
 package org.orleans.client
 import org.orleans.developer.twitter.TwitterMessages.{UserCreate, UserExists}
-import org.orleans.developer.twitter.{
-  Twitter,
-  TwitterAccount,
-  TwitterAcountRef,
-  TwitterRef
-}
+import org.orleans.developer.twitter.{Twitter, TwitterAccount, TwitterAcountRef, TwitterRef}
 import org.orleans.silo.Services.Grain.GrainRef
 import org.orleans.silo.Test.GreeterGrain
+import org.orleans.silo.storage.GrainDatabase
 
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -17,6 +14,7 @@ import scala.util.{Failure, Success, Try}
 object ClientMain {
 
   def main(args: Array[String]): Unit = {
+    GrainDatabase.disableDatabase = true
     val runtime = OrleansRuntime()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
@@ -31,74 +29,35 @@ object ClientMain {
     println(
       s"Creating a Twitter grain took ${System.currentTimeMillis() - time}ms")
 
-    val users = 10
-    println(s"Now creating $users users.")
+    val users = 50
     time = System.currentTimeMillis()
     for (i <- (1 to users)) {
       val user: TwitterAcountRef =
         Await.result(twitter.createAccount(s"wouter-${i}"), 5 seconds)
-    }
 
-    //Await.result(twitter.createAccount(s"wouter-${i}"), 1 seconds)
-    println(s"That took ${System.currentTimeMillis() - time}ms")
-
-    println(s"Now searching those $users users and show following list.")
-    time = System.currentTimeMillis()
-    for (i <- (1 to users)) {
-      val user = Await.result(twitter.getAccount(s"wouter-${i}"), 50 seconds)
-      for (j <- (1 to users)) {
-        if (i != j) {
-          Await.result(user.followUser(twitter, s"wouter-${j}"), 5 seconds)
-        }
+      for (i <- (1 to 1000)) {
+        user.tweet("a tweet!")
       }
-
-      val followers = Await.result(user.getFollowingList(), 50 seconds)
-      println(s"wouter-${i} - ${followers.size} followers")
     }
 
-    //Await.result(twitter.createAccount(s"wouter-${i}"), 1 seconds)
-    println(s"That took ${System.currentTimeMillis() - time}ms")
-
-    println(s"Now searching those $users users and send 10 000 tweets.")
+    println(s"Created users and tweeted: it took ${System.currentTimeMillis() - time}ms")
     time = System.currentTimeMillis()
+    val hash: mutable.HashMap[String, Int] = new mutable.HashMap[String, Int]()
     for (i <- (1 to users)) {
-      val user = Await.result(twitter.getAccount(s"wouter-${i}"), 50 seconds)
-      var futures: List[Future[Any]] = List()
-      for (j <- (1 to 10000)) {
-        user.tweet("I like dis")
+      val user: TwitterAcountRef =
+        Await.result(twitter.getAccount(s"wouter-${i}"), 5 seconds)
+      val tweets = Await.result(user.getTweets(), 5 seconds)
+
+      if (hash.contains(user.grainRef.address)) {
+        hash.put(user.grainRef.address, hash.get(user.grainRef.address).get + 1)
+      } else {
+        hash.put(user.grainRef.address, 1)
       }
-
     }
-    //Await.result(twitter.createAccount(s"wouter-${i}"), 1 seconds)
-    println(s"That took ${System.currentTimeMillis() - time}ms")
 
-    println("Waiting 5 seconds so all tweets are processed.")
-    Thread.sleep(5000)
-    println(s"Now searching those $users users and get amount of tweets..")
-    time = System.currentTimeMillis()
-    for (i <- (1 to users)) {
-      val user = Await.result(twitter.getAccount(s"wouter-${i}"), 50 seconds)
-      val size = Await.result(user.getAmountOfTweets(), 50 seconds)
-      println(s"wouter-${i} - $size tweets")
-    }
-    println(s"That took ${System.currentTimeMillis() - time}ms")
+    hash.foreach(println(_))
+    println(System.currentTimeMillis() - time)
+    System.exit(0)
 
-    println(s"Now searching those $users users and get all tweets.")
-    time = System.currentTimeMillis()
-    for (i <- (1 to users)) {
-      val user = Await.result(twitter.getAccount(s"wouter-${i}"), 50 seconds)
-      val tweets = Await.result(user.getTweets(), 50 seconds)
-      println(s"wouter-${i} - ${tweets.size} tweets")
-    }
-    println(s"That took ${System.currentTimeMillis() - time}ms")
-
-    println(s"Now searching those $users users and get their timeline")
-    time = System.currentTimeMillis()
-    for (i <- (1 to users)) {
-      val user = Await.result(twitter.getAccount(s"wouter-${i}"), 50 seconds)
-      val tweets = Await.result(user.getTimeline(twitter), 50 seconds)
-      println(s"wouter-${i} - ${tweets.size} tweets")
-    }
-    println(s"That took ${System.currentTimeMillis() - time}ms")
   }
 }

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -16,7 +16,7 @@ object Main {
     setLevel(Level.INFO) // The debug level might give a little bit too much info.
 
     GrainDatabase.setApplicationName("WouterTest")
-    GrainDatabase.disableDatabase = false
+    GrainDatabase.disableDatabase = true
 
     /**
       * A simple test-scenario is run here.
@@ -74,8 +74,8 @@ object Main {
 
     master.start()
     slave.start()
-    slave2.start()
-    slave3.start()
+//    slave2.start()
+//    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,9 +48,10 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(1901)
+      .setUDPPort(1900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,9 +48,10 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(19010)
+      .setUDPPort(1900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)
@@ -74,7 +75,6 @@ object Main {
     master.start()
     slave.start()
     slave2.start()
-//    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -51,7 +51,7 @@ object Main {
       .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(1900)
+      .setUDPPort(1901)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)
@@ -75,6 +75,7 @@ object Main {
     master.start()
     slave.start()
     slave2.start()
+    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -74,7 +74,7 @@ object Main {
     master.start()
     slave.start()
     slave2.start()
-    slave3.start()
+//    slave3.start()
 
     Thread.sleep(1000 * 20)
 

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -50,8 +50,8 @@ object Main {
       .registerGrain[TwitterAccount]
       .registerGrain[GreeterGrain]
       .setHost("localhost")
-      .setTCPPort(1800)
-      .setUDPPort(1900)
+      .setTCPPort(2800)
+      .setUDPPort(2900)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -34,6 +34,7 @@ object Main {
     val slave = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
+      .registerGrain[GreeterGrain]
       .setHost("localhost")
       .setTCPPort(1600)
       .setUDPPort(1700)
@@ -49,7 +50,7 @@ object Main {
       .registerGrain[TwitterAccount]
       .setHost("localhost")
       .setTCPPort(1800)
-      .setUDPPort(19010)
+      .setUDPPort(1901)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)
@@ -74,6 +75,9 @@ object Main {
     slave.start()
     slave2.start()
     slave3.start()
+
+    Thread.sleep(1000 * 20)
+
     //master.stop()
     //slave.stop()
   }

--- a/src/main/scala/org/orleans/silo/Main.scala
+++ b/src/main/scala/org/orleans/silo/Main.scala
@@ -48,10 +48,9 @@ object Main {
     val slave2 = Slave()
       .registerGrain[Twitter]
       .registerGrain[TwitterAccount]
-      .registerGrain[GreeterGrain]
       .setHost("localhost")
-      .setTCPPort(2800)
-      .setUDPPort(2900)
+      .setTCPPort(1800)
+      .setUDPPort(19010)
       .setMasterHost("localhost")
       .setMasterTCPPort(1400)
       .setMasterUDPPort(1500)

--- a/src/main/scala/org/orleans/silo/Master.scala
+++ b/src/main/scala/org/orleans/silo/Master.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.orleans.silo.Services.Grain.Grain
 import org.orleans.silo.communication.ConnectionProtocol.{Packet, PacketType, SlaveInfo}
 import org.orleans.silo.communication.{PacketListener, PacketManager, ConnectionProtocol => protocol}
-import org.orleans.silo.control.MasterGrain
+import org.orleans.silo.control.{GrainType, MasterGrain}
 import org.orleans.silo.dispatcher.Dispatcher
 import org.orleans.silo.metrics.LoadMonitor
 import org.orleans.silo.utils.GrainState.GrainState
@@ -111,8 +111,8 @@ class Master(
   val grainMap: ConcurrentHashMap[String, List[GrainInfo]] =
     new ConcurrentHashMap[String, List[GrainInfo]]()
 
-  val grainClassMap: ConcurrentHashMap[String, (ClassTag[_ <: Grain], TypeTag[_ <: Grain])] =
-    new ConcurrentHashMap[String, (ClassTag[_ <: Grain], TypeTag[_ <: Grain])]()
+  val grainClassMap: ConcurrentHashMap[String, GrainType[_ <: Grain]] =
+    new ConcurrentHashMap[String, GrainType[_ <: Grain]]()
 
   // Metadata for the master.
   val uuid: String = UUID.randomUUID().toString
@@ -364,9 +364,8 @@ class Master(
     * @param port   The port receiving from.
     */
   def processLoadData(packet: Packet, host: String, port: Int): Unit = {
-    logger.warn(s"Processing load data: ${packet.data} from slave ${packet.uuid}")
-    grainMap.forEach((k, v) => logger.warn(k + ":" + v))
-    grainClassMap.forEach((k, v) => logger.warn(k + ":" + v))
+    logger.debug(s"Processing load data: ${packet.data} from slave ${packet.uuid}")
+    grainMap.forEach((k, v) => logger.debug(k + ":" + v))
     packet.data.foreach { d =>
       d.split(":") match {
         case Array(id, load) => {
@@ -405,7 +404,7 @@ class Master(
           .foldLeft(0)((acc, b) => acc + b.load)
       })
       v.totalLoad = totalLoad
-      logger.warn("Slave load " + k + ":" + v.totalLoad)
+      logger.debug("Slave load " + k + ":" + v.totalLoad)
     }
   }
 

--- a/src/main/scala/org/orleans/silo/Master.scala
+++ b/src/main/scala/org/orleans/silo/Master.scala
@@ -285,7 +285,7 @@ class Master(
     *
     * @param packet The handshake packet.
     * @param host   The host receiving from.
-    * @param port   The port receiving from.
+    * @param udpPort   The port receiving from.
     */
   def processHandshake(packet: Packet, host: String, udpPort: Int): Unit = {
     // If slave is already in the cluster, we will not send another welcome packet. Its probably already received.

--- a/src/main/scala/org/orleans/silo/Master.scala
+++ b/src/main/scala/org/orleans/silo/Master.scala
@@ -197,6 +197,8 @@ class Master(
       if (timeDiff >= protocol.heartbeatInterval) {
         logger.debug("Sending heartbeats to slaves.")
 
+
+
         // Send its heartbeat to all slaves.
         val heartbeat = Packet(PacketType.HEARTBEAT, this.uuid, newTime)
         notifyAllSlaves(heartbeat)
@@ -386,13 +388,13 @@ class Master(
               "Slave reports about grain that master doesn't know about.")
           }
         }
-        case _ => logger.warn("Couldn't parse packet with metrics.")
+        case _ => logger.debug("Couldn't parse packet with metrics.")
       }
     }
     val slave: Option[SlaveInfo] = this.slaves.get(packet.uuid)
-    if (slave.isDefined) {
-      slave.get.totalGrains = slaveActivations
-    }
+//    if (slave.isDefined) {
+//      slave.get.totalGrains = slaveActivations
+//    }
     logger.debug(s"${this.grainMap}")
   }
 

--- a/src/main/scala/org/orleans/silo/Services/Grain/GrainRef.scala
+++ b/src/main/scala/org/orleans/silo/Services/Grain/GrainRef.scala
@@ -127,6 +127,9 @@ class GrainRef private (val id: String, val address: String, val port: Int)
 
         incoming = inStream.readObject().asInstanceOf[(String, GrainPacket)]
 
+//        if (expectedMessages.size() >= 0 && expectedMessages.size() <=100) {
+//          println(s"Still waiting for ${expectedMessages.size()}")
+//        }
         if (expectedMessages.size() == 0) {
           unExpectedMessages.put(incoming._1, incoming._2)
           logger.warn(

--- a/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
+++ b/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
@@ -22,5 +22,8 @@ class GreeterGrain(_id: String) extends Grain(_id) with LazyLogging {
       // Answer to the sender of the message
       // Asynchronous response
       sender ! "Hello World!"
+    case (msg: String, _) =>
+      Thread.sleep(25)
+      logger.info(s"Received message $msg")
   }
 }

--- a/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
+++ b/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
@@ -16,16 +16,16 @@ class GreeterGrain(_id: String) extends Grain(_id) with LazyLogging {
     */
   def receive = {
     case ("hi", _) =>
-      Thread.sleep(5000)
+//      Thread.sleep(5000)
       logger.info("Hello back to you")
     case ("hello", sender: Sender) =>
-      Thread.sleep(5000)
+//      Thread.sleep(5000)
       logger.info("Replying to the sender!")
       // Answer to the sender of the message
       // Asynchronous response
       sender ! "Hello World!"
     case (msg: String, _) =>
-      Thread.sleep(5000)
+//      Thread.sleep(5000)
       Thread.sleep(25)
       logger.info(s"Received message $msg")
   }

--- a/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
+++ b/src/main/scala/org/orleans/silo/Test/GreeterGrain.scala
@@ -16,13 +16,16 @@ class GreeterGrain(_id: String) extends Grain(_id) with LazyLogging {
     */
   def receive = {
     case ("hi", _) =>
+      Thread.sleep(5000)
       logger.info("Hello back to you")
     case ("hello", sender: Sender) =>
+      Thread.sleep(5000)
       logger.info("Replying to the sender!")
       // Answer to the sender of the message
       // Asynchronous response
       sender ! "Hello World!"
     case (msg: String, _) =>
+      Thread.sleep(5000)
       Thread.sleep(25)
       logger.info(s"Received message $msg")
   }

--- a/src/main/scala/org/orleans/silo/Test/TestLoadBalancing.scala
+++ b/src/main/scala/org/orleans/silo/Test/TestLoadBalancing.scala
@@ -1,0 +1,129 @@
+package org.orleans.silo.Test
+
+import org.orleans.silo.Services.Grain.GrainRef
+import org.orleans.silo.control.{ActiveGrainRequest, ActiveGrainResponse, CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+import scala.reflect.runtime.universe._
+import scala.reflect._
+
+object TestLoadBalancing {
+  // Testing load balancing.
+  // NOTE: To observe the effect add a Thread.sleep() to GreeterGrain receive() method.
+  def main(args: Array[String]): Unit = {
+    println("Trying to get the socket")
+
+    var id: String = ""
+
+    val classtag = classTag[GreeterGrain]
+    val typetag = typeTag[GreeterGrain]
+
+    // The master grain in the master has ID "master" so it's easy to find!
+    val g = GrainRef("master", "localhost", 1400)
+
+    // Try to create a grain
+    println("Creating the grain!")
+    val result = g ? CreateGrainRequest(classtag, typetag)
+    val mappedResult = result.map {
+      case value: CreateGrainResponse =>
+        println("Received CreateGrainResponse!")
+        println(value)
+        id = value.id
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResult, 5 seconds)
+
+    println(s"ID of the grain is $id")
+
+    // Search for the grain.
+    // Only 1 activation exists by now.
+    println("Searching for the grain")
+    var port : Int = 0
+    // Search for a grain
+    g ? SearchGrainRequest(id, classtag, typetag) onComplete {
+      case Success(value: SearchGrainResponse) =>
+        println(value)
+        port = value.port
+      case Failure(exception) => exception.printStackTrace()
+    }
+    Thread.sleep(1000)
+
+    // Turn on logging in Master's processLoadData() method and
+    // see how the queue piles up.
+    println("Sending hello to the greeter grain")
+    val g1 : GrainRef = GrainRef(id, "localhost", port)
+    for (i ← (1 to 15)) {
+      Thread.sleep(250)
+      g1 ! s"hello from $i"
+    }
+
+    Thread.sleep(3000)
+    // Create another activation of the same grain.
+    // Also see if the activation will be created on different slave (It should).
+    println("Try to activate other grain")
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(2000)
+
+    // Create another grain.
+    // Also see if the grain will be created on different slave (It should).
+//    var id1 = ""
+//    println("Creating the other grain!")
+//    val result1 = g ? CreateGrainRequest(classtag, typetag)
+//    val mappedResult1 = result1.map {
+//      case value: CreateGrainResponse =>
+//        println("Received CreateGrainResponse!")
+//        println(value)
+//        id1 = value.id
+//      case other => println(s"Something went wrong: $other")
+//    }
+//    Await.result(mappedResult1, 5 seconds)
+//
+//    println(s"ID of the grain is $id1")
+
+    // Search for the grain.
+    // 2 activations exists. Searching should return slave with lower total load.
+    // (See the logs in Master's processLoadData() method to verify)
+    var port2 = 0
+    println("Searching for the grain")
+    g ? SearchGrainRequest(id, classtag, typetag) onComplete {
+      case Success(value: SearchGrainResponse) =>
+        println(value)
+        port2 = value.port
+      case Failure(exception) => exception.printStackTrace()
+    }
+    Thread.sleep(1000)
+
+    println("Sending hello to the greeter grain")
+    val g2 : GrainRef = GrainRef(id, "localhost", port2)
+    for (i ← (1 to 15)) {
+      Thread.sleep(250)
+      g2 ! s"hello from $i"
+    }
+
+    Thread.sleep(500000)
+
+    // Delete that grain
+    println("Trying to delete grain")
+    // Try to delete the grain
+    g ! DeleteGrainRequest(id)
+  }
+
+  def time[R](block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block // call-by-name
+    val t1 = System.nanoTime()
+    println("Elapsed time: " + (t1 - t0) / 1e6 + "ms")
+    result
+  }
+}

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -1,7 +1,7 @@
 package org.orleans.silo.Test
 
 import org.orleans.silo.Services.Grain.GrainRef
-import org.orleans.silo.control.{CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
+import org.orleans.silo.control.{ActiveGrainRequest, ActiveGrainResponse, CreateGrainRequest, CreateGrainResponse, DeleteGrainRequest, SearchGrainRequest, SearchGrainResponse}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -27,19 +27,19 @@ object Testing {
 //    val g = GrainRef("1234", "localhost", 1400)
 
     // Try to search for a grain that is deactivated
-    g ? SearchGrainRequest("29d95c86-b744-43cc-9de3-23a0e40c21c3", classtag, typetag) onComplete {
-      case Success(value: SearchGrainResponse) =>
-        println("Succesfully activate persistant grain by search!")
-        println(value)
-      case Success(value) =>
-        println(s"Unknown return value received: $value!")
-      case Failure(exception) => exception.printStackTrace()
-    }
-    Thread.sleep(1000)
+//    g ? SearchGrainRequest("962d24a3-5b31-41ba-aaeb-60ca4bd69b4d", classtag, typetag) onComplete {
+//      case Success(value: SearchGrainResponse) =>
+//        println("Succesfully activate persistant grain by search!")
+//        println(value)
+//      case Success(value) =>
+//        println(s"Unknown return value received: $value!")
+//      case Failure(exception) => exception.printStackTrace()
+//    }
+//    Thread.sleep(100000)
 
 
 
-    // Try to create a grain
+//     Try to create a grain
     println("Creating the grain!")
     val result = g ? CreateGrainRequest(classtag, typetag)
     val mappedResult = result.map {
@@ -52,7 +52,32 @@ object Testing {
     Await.result(mappedResult, 5 seconds)
 
     println(s"ID of the grain is $id")
+
+    Thread.sleep(3000)
+    println("Try to activate other grain")
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(5000)
     println("Searching for the grain")
+
+    println("Try to activate other grain")
+    val resultActivate1 = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate1 = resultActivate1.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate1, 5 seconds)
+
+    Thread.sleep(5000)
 
     var port : Int = 0
 
@@ -63,7 +88,7 @@ object Testing {
         port = value.port
       case Failure(exception) => exception.printStackTrace()
     }
-    Thread.sleep(1000)
+    Thread.sleep(5000)
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
@@ -72,8 +97,8 @@ object Testing {
       case _ => "Not working"
     }
 
-    Thread.sleep(5000)
-
+    Thread.sleep(15000)
+//
     // Delete that grain
     println("Trying to delete grain")
     // Try to delete the grain

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -56,16 +56,16 @@ object Testing {
     Thread.sleep(3000)
 //    Create another activation to test replication on the same slave (to test, you need to start only 1 slave)
 //    println("Try to activate other grain")
-//    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
-//    val mappedResultActivate = resultActivate.map {
-//      case value: ActiveGrainResponse =>
-//        println("Received ActiveGrainResponse!")
-//        println(value)
-//      case other => println(s"Something went wrong: $other")
-//    }
-//    Await.result(mappedResultActivate, 5 seconds)
-//
-//    Thread.sleep(5000)
+    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+    val mappedResultActivate = resultActivate.map {
+      case value: ActiveGrainResponse =>
+        println("Received ActiveGrainResponse!")
+        println(value)
+      case other => println(s"Something went wrong: $other")
+    }
+    Await.result(mappedResultActivate, 5 seconds)
+
+    Thread.sleep(5000)
     println("Searching for the grain")
     var port : Int = 0
 
@@ -80,17 +80,20 @@ object Testing {
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
-    g2 ? "hello" onComplete{
-      case Success(value) => println(value)
-      case _ => "Not working"
+    for (i ← (1 to 1000)) {
+      g2 ! s"hello from $i"
     }
+//    g2 ? "hello" onComplete{
+//      case Success(value) => println(value)
+//      case _ => "Not working"
+//    }
 
     Thread.sleep(5000)
 //
     // Delete that grain
-    println("Trying to delete grain")
-    // Try to delete the grain
-    g ! DeleteGrainRequest(id)
+//    println("Trying to delete grain")
+//    // Try to delete the grain
+//    g ! DeleteGrainRequest(id)
 
   }
 

--- a/src/main/scala/org/orleans/silo/Test/Testing.scala
+++ b/src/main/scala/org/orleans/silo/Test/Testing.scala
@@ -54,31 +54,19 @@ object Testing {
     println(s"ID of the grain is $id")
 
     Thread.sleep(3000)
-    println("Try to activate other grain")
-    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
-    val mappedResultActivate = resultActivate.map {
-      case value: ActiveGrainResponse =>
-        println("Received ActiveGrainResponse!")
-        println(value)
-      case other => println(s"Something went wrong: $other")
-    }
-    Await.result(mappedResultActivate, 5 seconds)
-
-    Thread.sleep(5000)
+//    Create another activation to test replication on the same slave (to test, you need to start only 1 slave)
+//    println("Try to activate other grain")
+//    val resultActivate = g ? ActiveGrainRequest(id, classtag, typetag)
+//    val mappedResultActivate = resultActivate.map {
+//      case value: ActiveGrainResponse =>
+//        println("Received ActiveGrainResponse!")
+//        println(value)
+//      case other => println(s"Something went wrong: $other")
+//    }
+//    Await.result(mappedResultActivate, 5 seconds)
+//
+//    Thread.sleep(5000)
     println("Searching for the grain")
-
-    println("Try to activate other grain")
-    val resultActivate1 = g ? ActiveGrainRequest(id, classtag, typetag)
-    val mappedResultActivate1 = resultActivate1.map {
-      case value: ActiveGrainResponse =>
-        println("Received ActiveGrainResponse!")
-        println(value)
-      case other => println(s"Something went wrong: $other")
-    }
-    Await.result(mappedResultActivate1, 5 seconds)
-
-    Thread.sleep(5000)
-
     var port : Int = 0
 
     // Search for a grain
@@ -88,7 +76,7 @@ object Testing {
         port = value.port
       case Failure(exception) => exception.printStackTrace()
     }
-    Thread.sleep(5000)
+    Thread.sleep(1000)
 
     println("Sending hello to the greeter grain")
     val g2 : GrainRef = GrainRef(id, "localhost", port)
@@ -97,7 +85,7 @@ object Testing {
       case _ => "Not working"
     }
 
-    Thread.sleep(15000)
+    Thread.sleep(5000)
 //
     // Delete that grain
     println("Trying to delete grain")

--- a/src/main/scala/org/orleans/silo/communication/ConnectionProtocol.scala
+++ b/src/main/scala/org/orleans/silo/communication/ConnectionProtocol.scala
@@ -24,7 +24,8 @@ object ConnectionProtocol {
                        udpPort: Int,
                        tcpPort: Int,
                        lastHeartbeat: Long = -1,
-                       var totalLoad: Int = 0)
+                       var totalLoad: Int = 0,
+                       var totalGrains: Int = 0)
 
   // The interval for which heart beats are sent.
   val heartbeatInterval: Long = 1000

--- a/src/main/scala/org/orleans/silo/control/GrainType.scala
+++ b/src/main/scala/org/orleans/silo/control/GrainType.scala
@@ -1,0 +1,8 @@
+package org.orleans.silo.control
+
+import org.orleans.silo.Services.Grain.Grain
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+case class GrainType[T <: Grain](classTag: ClassTag[T], typeTag: TypeTag[T])

--- a/src/main/scala/org/orleans/silo/control/MasterGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/MasterGrain.scala
@@ -175,7 +175,7 @@ class MasterGrain(_id: String, master: Master)
                                  sender: Sender): Unit = {
     // Now get the least loaded slave
     val info: SlaveInfo = master.slaves.values.reduceLeft((x, y) =>
-      if (x.totalLoad < y.totalLoad) x else y)
+      if (x.totalGrains < y.totalGrains) x else y)
 
     var slaveRef: GrainRef = null
     if (!slaveGrainRefs.containsKey(info.uuid)) {

--- a/src/main/scala/org/orleans/silo/control/MasterGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/MasterGrain.scala
@@ -177,6 +177,9 @@ class MasterGrain(_id: String, master: Master)
     val info: SlaveInfo = master.slaves.values.reduceLeft((x, y) =>
       if (x.totalGrains < y.totalGrains) x else y)
 
+    info.totalGrains = info.totalGrains + 1
+    //logger.info(s"total grains ${info.tcpPort} ${info.totalGrains}")
+
     var slaveRef: GrainRef = null
     if (!slaveGrainRefs.containsKey(info.uuid)) {
       slaveRef = GrainRef(info.uuid, info.host, info.tcpPort)

--- a/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
@@ -121,6 +121,7 @@ class SlaveGrain(_id: String, slave: Slave)
 
       // Get the ID for the newly created grain
       // It is necessary to add the typeTag here because the dispacther type is eliminated by type erasure
+
       val id = dispatcher.addGrain(typeTag)
 
       // Add it to the grainMap

--- a/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
@@ -35,7 +35,7 @@ class SlaveGrain(_id: String, slave: Slave)
   private def getOrCreateDispatcher[T <: Grain: ClassTag: TypeTag]()
     : Dispatcher[T] = {
     if (!slave.registeredGrains.exists(tuple => tuple._1 == classTag[T])) {
-      logger.info(s"Creating new dispatcher for class: ${typeTag}")
+      logger.warn(s"Creating new dispatcher for class: ${typeTag}")
       val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
@@ -55,7 +55,7 @@ class SlaveGrain(_id: String, slave: Slave)
         .head
         .asInstanceOf[Dispatcher[T]]
 
-      logger.info(s"Found dispatcher for class: ${typeTag}")
+      logger.warn(s"Found dispatcher for class: ${typeTag}")
 
       dispatcher
     }
@@ -204,7 +204,9 @@ class SlaveGrain(_id: String, slave: Slave)
     dispatcher.addActivation(request.id, request.grainType)
 
     // Add it to the grainMap
-    logger.info(s"Adding to the slave grainmap id ${request.id}")
+    logger.info(s"Adding activation to the slave grainmap id ${request.id}")
+
+    //TODO GrainMap has to differentiate grains by port also
     slave.grainMap.put(request.id, classTag[T])
 
     sender ! ActiveGrainResponse(slave.slaveConfig.host, dispatcher.port)

--- a/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
+++ b/src/main/scala/org/orleans/silo/control/SlaveGrain.scala
@@ -36,7 +36,7 @@ class SlaveGrain(_id: String, slave: Slave)
     : Dispatcher[T] = {
     if (!slave.registeredGrains.exists(tuple => tuple._1 == classTag[T])) {
       logger.warn(s"Creating new dispatcher for class: ${typeTag}")
-      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
+      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort, Option(null))
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
 
@@ -55,7 +55,7 @@ class SlaveGrain(_id: String, slave: Slave)
         .head
         .asInstanceOf[Dispatcher[T]]
 
-      logger.warn(s"Found dispatcher for class: ${typeTag}")
+      logger.debug(s"Found dispatcher for class: ${typeTag}")
 
       dispatcher
     }
@@ -135,7 +135,7 @@ class SlaveGrain(_id: String, slave: Slave)
       logger.debug(
         s"Creating new dispatcher for class ${request.grainClass.runtimeClass}")
       // Create a new dispatcher for that and return its properties
-      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort)
+      val dispatcher: Dispatcher[T] = new Dispatcher[T](slave.getFreePort, Option(null))
       // Add the dispatchers to the dispatcher
       slave.dispatchers = dispatcher :: slave.dispatchers
       val id: String = dispatcher.addGrain(typeTag)
@@ -206,7 +206,6 @@ class SlaveGrain(_id: String, slave: Slave)
     // Add it to the grainMap
     logger.info(s"Adding activation to the slave grainmap id ${request.id}")
 
-    //TODO GrainMap has to differentiate grains by port also
     slave.grainMap.put(request.id, classTag[T])
 
     sender ! ActiveGrainResponse(slave.slaveConfig.host, dispatcher.port)

--- a/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
@@ -17,7 +17,7 @@ import collection.JavaConverters._
 class ClientCleanup(clientSockets: util.List[MessageReceiver])
     extends TimerTask
     with LazyLogging {
-  val CLIENT_REMOVE_TIME_SEC: Int = 10
+  val CLIENT_REMOVE_TIME_SEC: Int = 100000
   override def run(): Unit = {
     val toRemove: util.List[MessageReceiver] =
       new util.ArrayList[MessageReceiver]()
@@ -46,7 +46,7 @@ class ClientCleanup(clientSockets: util.List[MessageReceiver])
   }
 }
 class ClientReceiver[T <: Grain: ClassTag](
-    val mailboxIndex: ConcurrentHashMap[String, Mailbox],
+    val mailboxIndex: ConcurrentHashMap[String, List[Mailbox]],
     port: Int)
     extends Runnable
     with LazyLogging {

--- a/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/ClientReceiver.scala
@@ -17,7 +17,7 @@ import collection.JavaConverters._
 class ClientCleanup(clientSockets: util.List[MessageReceiver])
     extends TimerTask
     with LazyLogging {
-  val CLIENT_REMOVE_TIME_SEC: Int = 100000
+  val CLIENT_REMOVE_TIME_SEC: Int = 10
   override def run(): Unit = {
     val toRemove: util.List[MessageReceiver] =
       new util.ArrayList[MessageReceiver]()
@@ -47,7 +47,7 @@ class ClientCleanup(clientSockets: util.List[MessageReceiver])
 }
 class ClientReceiver[T <: Grain: ClassTag](
     val mailboxIndex: ConcurrentHashMap[String, List[Mailbox]],
-    port: Int)
+    port: Int, val registryFactory: Option[RegistryFactory])
     extends Runnable
     with LazyLogging {
 
@@ -86,7 +86,7 @@ class ClientReceiver[T <: Grain: ClassTag](
       }
 
       // Create new client when
-      val messageReceiver = new MessageReceiver(mailboxIndex, clientSocket)
+      val messageReceiver = new MessageReceiver(mailboxIndex, registryFactory, clientSocket)
       val mRecvThread: Thread = new Thread(messageReceiver)
       logger.info(s"Message-Receiver started on ${clientSocket.getPort}.")
       mRecvThread.setName(

--- a/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
@@ -106,6 +106,7 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
     val mailbox = new Mailbox(grain, registryFactory)
 
     this.grainMap.put(mailbox, grain)
+    this.grainMap.forEach((mbox, grain) => logger.info(s"Mailbox ${mbox.id} --> $grain"))
     val currentMailboxes: List[Mailbox] = this.clientReceiver.mailboxIndex.getOrDefault(grain._id, List())
     this.clientReceiver.mailboxIndex.put(grain._id, mailbox :: currentMailboxes)
   }
@@ -188,6 +189,7 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
           pool.execute(mbox)
         }
       })
+      Thread.sleep(SLEEP_TIME)
     }
   }
 

--- a/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/Dispatcher.scala
@@ -91,6 +91,13 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
 
     val currentMailboxes: List[Mailbox] = this.clientReceiver.mailboxIndex.getOrDefault(id, List())
     this.clientReceiver.mailboxIndex.put(id, mbox :: currentMailboxes)
+    if (registryFactory.isDefined) {
+      val registry: Registry =
+        registryFactory.get.getOrCreateRegistry(id)
+      registry.addActiveGrain()
+    }
+
+
     // Return the id of the grain
     id
   }
@@ -109,6 +116,11 @@ class Dispatcher[T <: Grain: ClassTag: TypeTag](val port: Int, val registryFacto
     this.grainMap.forEach((mbox, grain) => logger.info(s"Mailbox ${mbox.id} --> $grain"))
     val currentMailboxes: List[Mailbox] = this.clientReceiver.mailboxIndex.getOrDefault(grain._id, List())
     this.clientReceiver.mailboxIndex.put(grain._id, mailbox :: currentMailboxes)
+    if (registryFactory.isDefined) {
+      val registry: Registry =
+        registryFactory.get.getOrCreateRegistry(id)
+      registry.addActiveGrain()
+    }
   }
 
   /**

--- a/src/main/scala/org/orleans/silo/dispatcher/Mailbox.scala
+++ b/src/main/scala/org/orleans/silo/dispatcher/Mailbox.scala
@@ -2,6 +2,7 @@ package org.orleans.silo.dispatcher
 
 import java.io.ObjectOutputStream
 import java.net.Socket
+import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -48,7 +49,7 @@ private[dispatcher] class Mailbox(val grain: Grain, val registryFactory: Option[
     with LazyLogging {
   private[dispatcher] val inbox = new LinkedBlockingQueue[Message]
   // id of the mailbox
-  val id: String = grain._id
+  val id: String = UUID.randomUUID().toString
 
   // length of the message queue for that actor
   def length: Int = inbox.size()
@@ -87,7 +88,7 @@ private[dispatcher] class Mailbox(val grain: Grain, val registryFactory: Option[
       grain.receive((msg.msg, msg.sender))
       if (registryFactory.isDefined) {
         val registry: Registry =
-          registryFactory.get.getOrCreateRegistry(id)
+          registryFactory.get.getOrCreateRegistry(grain._id)
         registry.addRequestHandled()
       }
     }

--- a/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
@@ -1,0 +1,39 @@
+package org.orleans.silo.metrics
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.typesafe.scalalogging.LazyLogging
+import org.orleans.silo.GrainInfo
+import org.orleans.silo.control.MasterGrain
+
+class LoadMonitor(val grainMap: ConcurrentHashMap[String, List[GrainInfo]], val masterGrain: MasterGrain)
+  extends Runnable with LazyLogging{
+
+  var running: Boolean = true
+  val FREQUENCY: Int = 1000
+  // Final value to figure out
+  val REPLICATION_TRESHOLD = 10
+
+  override def run(): Unit = {
+    logger.warn("Started load monitor on master.")
+    var oldTime: Long = System.currentTimeMillis()
+
+    while (running) {
+      val newTime: Long = System.currentTimeMillis()
+      val timeDiff = newTime - oldTime
+
+      // Check if it is time to send heartbeats again.
+      if (timeDiff >= FREQUENCY) {
+        oldTime = newTime
+        grainMap.forEach((id, grainList) => {
+          val avgLoad: Double = grainList.foldLeft(0.0)((acc, b) => acc + b.load) / grainList.length
+          if (avgLoad > REPLICATION_TRESHOLD) {
+            masterGrain.triggerGrainReplication(id)
+          }
+        }
+        )
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/LoadMonitor.scala
@@ -12,7 +12,7 @@ class LoadMonitor(val grainMap: ConcurrentHashMap[String, List[GrainInfo]], val 
   var running: Boolean = true
   val FREQUENCY: Int = 1000
   // Final value to figure out
-  val REPLICATION_TRESHOLD = 10
+  val REPLICATION_TRESHOLD = 100
 
   override def run(): Unit = {
     logger.warn("Started load monitor on master.")

--- a/src/main/scala/org/orleans/silo/metrics/MetricsExtractor.scala
+++ b/src/main/scala/org/orleans/silo/metrics/MetricsExtractor.scala
@@ -8,8 +8,8 @@ object MetricsExtractor {
    * @return Number of pending requests.
    */
   def getPendingRequests(registry: Registry): Int = {
-    val started = registry.requestsReceived
-    val handled = registry.requestsHandled
+    val started = registry.requestsReceived.get()
+    val handled = registry.requestsHandled.get()
     started - handled
   }
 

--- a/src/main/scala/org/orleans/silo/metrics/Registry.scala
+++ b/src/main/scala/org/orleans/silo/metrics/Registry.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class Registry() {
   var requestsReceived: AtomicInteger = new AtomicInteger(0)
   var requestsHandled: AtomicInteger = new AtomicInteger(0)
+  var grainsActivated: AtomicInteger = new AtomicInteger(0)
 
   /**
    * Increase the counter of requests received.
@@ -21,5 +22,12 @@ class Registry() {
    */
   def addRequestHandled(): Unit = {
     requestsHandled.addAndGet(1)
+  }
+
+  /**
+   * Increase the counter of active Grains.
+   */
+  def addActiveGrain(): Unit = {
+    grainsActivated.addAndGet(1)
   }
 }

--- a/src/main/scala/org/orleans/silo/metrics/Registry.scala
+++ b/src/main/scala/org/orleans/silo/metrics/Registry.scala
@@ -1,25 +1,25 @@
 package org.orleans.silo.metrics
 
+import java.util.concurrent.atomic.AtomicInteger
+
 /**
  * Registry for collecting information about requests toi grain.
  */
 class Registry() {
-  @volatile
-  var requestsReceived: Int = 0
-  @volatile
-  var requestsHandled: Int = 0
+  var requestsReceived: AtomicInteger = new AtomicInteger(0)
+  var requestsHandled: AtomicInteger = new AtomicInteger(0)
 
   /**
    * Increase the counter of requests received.
    */
   def addRequestReceived(): Unit = {
-    requestsReceived += 1
+    requestsReceived.addAndGet(1)
   }
 
   /**
    * Increase the counter of requests processed.
    */
   def addRequestHandled(): Unit = {
-    requestsHandled += 1
+    requestsHandled.addAndGet(1)
   }
 }

--- a/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
+++ b/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
@@ -50,10 +50,10 @@ class RegistryFactory extends LazyLogging{
    *
    * @return Map of loads per service.
    */
-  def getRegistryLoads(): Map[String, Int] = {
-    var loads: Map[String, Int] = Map()
+  def getRegistryLoads(): Map[String, (Int, Int)] = {
+    var loads: Map[String, (Int, Int)] = Map()
     this.registries.forEach((id, registry) => {
-      loads += (id ->  MetricsExtractor.getPendingRequests(registry))
+      loads += (id ->  (MetricsExtractor.getPendingRequests(registry), registry.grainsActivated.get()))
     })
     loads
   }

--- a/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
+++ b/src/main/scala/org/orleans/silo/metrics/RegistryFactory.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import com.typesafe.scalalogging.LazyLogging
 import org.orleans.silo.GrainInfo
 
-object RegistryFactory extends LazyLogging{
+class RegistryFactory extends LazyLogging{
 
   // Active registries collecting metrics on different services.
   private val registries: ConcurrentHashMap[String, Registry] = new ConcurrentHashMap[String, Registry]()


### PR DESCRIPTION
Changes:

- Multiple activations of the same grain are now possible on the same slave. MailboxIndex now store List of Mailboxes and MessageReceiver chooses a mailbox to put a message to by the current size of the mailbox.

- RegistryFactory for grains is now instantiated for each slave (not global anymore) so we don't have this spam of logs when we test locally. Note that metrics will be collected only for grain types that you register when starting the slaves.

- Minor changes in storing the grainMap in Master i.e: avoid duplication of entries form the replicas of the same grain on the same slave (master sees such activations as one).

- Grain can be now replicated automatically.